### PR TITLE
Fixed getWall.js

### DIFF
--- a/lib/group/getWall.js
+++ b/lib/group/getWall.js
@@ -24,7 +24,7 @@ function getPosts (wall, body, page, view) {
       return 0;
     }
   }
-  var totalPages = parseInt($('#ctl00_cphRoblox_GroupWallPane_GroupWallPager_ctl01_Div1').find('.paging_pagenums_container').text(), 10);
+  var totalPages = parseInt(/Page (\d+)/.exec($('#ctl00_cphRoblox_GroupWallPane_GroupWallPager_ctl01_Div1').text())[1], 10);
   if (wall) {
     var posts = $('.GroupWall_PostContainer');
     for (var i = 0; i < posts.length; i++) {


### PR DESCRIPTION
Fixed the `totalPages ` variable using an outdated method to fetch wall posts, solution by '[DevKurka](https://devforum.roblox.com/u/devkurka/summary)'